### PR TITLE
make root & relativeTo options relative to source tree

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -3,6 +3,5 @@
 module.exports = require('./index')('test/fixtures', {
   keepSpecialComments: 1,
   keepBreaks: true,
-  noAdvanced: true,
-  root: 'test/fixtures'
+  noAdvanced: true
 });

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 var Filter = require('broccoli-filter');
 var CleanCSS = require('clean-css');
+var path = require('path');
 
 function CleanCSSFilter(inputTree, options) {
   if (!(this instanceof CleanCSSFilter)) {
@@ -10,6 +11,7 @@ function CleanCSSFilter(inputTree, options) {
 
   this.inputTree = inputTree;
   this.options = options || {};
+  this.cleaner = null;
 }
 
 CleanCSSFilter.prototype = Object.create(Filter.prototype);
@@ -18,8 +20,25 @@ CleanCSSFilter.prototype.constructor = CleanCSSFilter;
 CleanCSSFilter.prototype.extensions = ['css'];
 CleanCSSFilter.prototype.targetExtension = 'css';
 
+// add hook to read
+CleanCSSFilter.prototype.read = function(readTree) {
+  var self = this, args = arguments;
+
+  return readTree(this.inputTree).then(function (srcDir) {
+    // rewrite relative paths to resolve against the source tree
+    self.options.root = path.resolve(srcDir, self.options.root || '.');
+    if (self.options.relativeTo) {
+      self.options.relativeTo = path.resolve(srcDir, self.options.relativeTo);
+    }
+
+    self.cleaner = new CleanCSS(self.options);
+
+    return Filter.prototype.read.apply(self, args);
+  });
+};
+
 CleanCSSFilter.prototype.processString = function(str) {
-  return new CleanCSS(this.options).minify(str);
+  return this.cleaner.minify(str);
 };
 
 module.exports = CleanCSSFilter;


### PR DESCRIPTION
Previously the options would be relative to the current working directory, which didn't really make any sense.

I also used the opportunity to only create one instance of CleanCSS.
