### PR TITLE
disableStrict for clean-css-promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function CleanCSSFilter(inputTree, options) {
 
   this.options = options;
 
-  if (typeof this.options.disableStrict === 'undefined') {
+  if (this.options.disableStrict === undefined) {
     this.options.disableStrict = true;
   }
 

--- a/index.js
+++ b/index.js
@@ -20,7 +20,11 @@ function CleanCSSFilter(inputTree, options) {
   });
 
   this.options = options;
-  this.options.disableStrict = true;
+
+  if (typeof this.options.disableStrict === 'undefined') {
+    this.options.disableStrict = true;
+  }
+
   this._cleanCSS = null;
 }
 

--- a/index.js
+++ b/index.js
@@ -1,22 +1,26 @@
 'use strict';
 
 var path = require('path');
-
 var CleanCssPromise = require('clean-css-promise');
 var Filter = require('broccoli-persistent-filter');
-var inlineSourceMapComment = require('inline-source-map-comment');
 var jsonStableStringify = require('json-stable-stringify');
+var inlineSourceMapComment = require('inline-source-map-comment');
 
 function CleanCSSFilter(inputTree, options) {
   if (!(this instanceof CleanCSSFilter)) {
     return new CleanCSSFilter(inputTree, options);
   }
 
+  options = options || {};
+
   this.inputTree = inputTree;
 
-  Filter.call(this, inputTree, options);
+  Filter.call(this, inputTree, {
+    annotation: options.annotation
+  });
 
-  this.options = options || {};
+  this.options = options;
+  this.options.disableStrict = true;
   this._cleanCSS = null;
 }
 


### PR DESCRIPTION
In 1.1.0, strict was removed when it was enabled by default.  Depends on https://github.com/shinnn/clean-css-promise/pull/1

See: https://github.com/shinnn/broccoli-clean-css/issues/14

Tests are currently failing on master, I can fix them as well in a follow up PR.